### PR TITLE
Add GraphQL endpoint for team member meta data

### DIFF
--- a/themes/wds_headless/inc/custom-post-types.php
+++ b/themes/wds_headless/inc/custom-post-types.php
@@ -56,10 +56,18 @@ function wds_register_custom_post_types() {
 }
 add_action( 'init', 'wds_register_custom_post_types' );
 
+/**
+ * Register a field on the Team GraphQL object and populate it with post meta.
+ *
+ * Provided as an example; not currently needed.
+ *
+ * @author WebDevStudios
+ * @since 1.0
+ */
 function wds_register_team_profile_data() {
 	register_graphql_field( 'Team', 'profileData', [
 		'type'        => 'String',
-		'description' => __( 'Extra metadata for team members', 'wds' ),
+		'description' => esc_html__( 'Extra metadata for team members', 'wds' ),
 		'resolve'     => function( $post ) {
 			$team_meta_keys = [
 				'title',
@@ -82,4 +90,4 @@ function wds_register_team_profile_data() {
 		},
 	] );
 }
-add_action( 'graphql_register_types', 'wds_register_team_profile_data' );
+//add_action( 'graphql_register_types', 'wds_register_team_profile_data' );

--- a/themes/wds_headless/inc/custom-post-types.php
+++ b/themes/wds_headless/inc/custom-post-types.php
@@ -56,7 +56,7 @@ function wds_register_custom_post_types() {
 }
 add_action( 'init', 'wds_register_custom_post_types' );
 
-add_action( 'graphql_register_types', function() {
+function wds_register_team_profile_data() {
 	register_graphql_field( 'Team', 'profileData', [
 		'type'        => 'String',
 		'description' => __( 'Extra metadata for team members', 'wds' ),
@@ -81,4 +81,5 @@ add_action( 'graphql_register_types', function() {
 			return wp_json_encode( $profile_data );
 		},
 	] );
-} );
+}
+add_action( 'graphql_register_types', 'wds_register_team_profile_data' );

--- a/themes/wds_headless/inc/custom-post-types.php
+++ b/themes/wds_headless/inc/custom-post-types.php
@@ -55,3 +55,30 @@ function wds_register_custom_post_types() {
 	register_post_type( "team", $args );
 }
 add_action( 'init', 'wds_register_custom_post_types' );
+
+add_action( 'graphql_register_types', function() {
+	register_graphql_field( 'Team', 'profileData', [
+		'type'        => 'String',
+		'description' => __( 'Extra metadata for team members', 'wds' ),
+		'resolve'     => function( $post ) {
+			$team_meta_keys = [
+				'title',
+				'location',
+				'linkedin_url',
+				'twitter_url',
+				'facebook_url',
+				'instagram_url',
+				'wordpressorg_profile_url',
+				'github_url',
+				'website_url',
+				'easter_egg_url',
+			];
+			$profile_data   = [];
+
+			foreach ( $team_meta_keys as $key ) {
+				$profile_data[ $key ] = get_post_meta( $post->ID, $key, true );
+			}
+			return wp_json_encode( $profile_data );
+		},
+	] );
+} );


### PR DESCRIPTION
### Feature Description
Added a new field to team members in GraphQL that gets the profile fields as a JSON object.

### Feature Screenshots
<img width="720" alt="image" src="https://user-images.githubusercontent.com/1427716/106817024-4bc5de00-6644-11eb-962e-66b7f640db77.png">


### Steps To Verify Feature
Use this query in GraphiQL:

```graphql
query GET_TEAM_BY_ID {
  team(id: "jim-byrom", idType: SLUG) {
    profileData
  }
}
```