### PR TITLE
Feature/acf-block-example

### DIFF
--- a/themes/wds_headless/acf-json/group_601bfb9db9871.json
+++ b/themes/wds_headless/acf-json/group_601bfb9db9871.json
@@ -1,0 +1,128 @@
+{
+    "key": "group_601bfb9db9871",
+    "title": "Block: ACF Media Text",
+    "fields": [
+        {
+            "key": "field_601bfba98c0c8",
+            "label": "Title",
+            "name": "title",
+            "type": "text",
+            "instructions": "Enter the title.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_601bfbcb8c0c9",
+            "label": "Body",
+            "name": "body",
+            "type": "textarea",
+            "instructions": "Enter the body text.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "default_value": "",
+            "placeholder": "",
+            "maxlength": "",
+            "rows": "",
+            "new_lines": ""
+        },
+        {
+            "key": "field_601bfbd78c0ca",
+            "label": "CTA Text",
+            "name": "ctaText",
+            "type": "text",
+            "instructions": "Enter some text for the CTA button.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_601bfbf38c0cb",
+            "label": "CTA URL",
+            "name": "ctaUrl",
+            "type": "url",
+            "instructions": "Enter a URL for the CTA button.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "default_value": "",
+            "placeholder": ""
+        },
+        {
+            "key": "field_601bfc288c0cc",
+            "label": "Image",
+            "name": "image",
+            "type": "image",
+            "instructions": "Pick an image to display.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "return_format": "url",
+            "preview_size": "medium",
+            "library": "all",
+            "min_width": "",
+            "min_height": "",
+            "min_size": "",
+            "max_width": "",
+            "max_height": "",
+            "max_size": "",
+            "mime_types": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/acf-media-text"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_graphql": 0,
+    "graphql_field_name": "block_acf_media_text",
+    "modified": 1612469771
+}

--- a/themes/wds_headless/inc/blocks.php
+++ b/themes/wds_headless/inc/blocks.php
@@ -71,5 +71,22 @@ function wds_acf_blocks_init() {
 			'supports'        => $supports,
 		]
 	);
+
+	// Media Text.
+	acf_register_block_type(
+		[
+			'name'            => 'acf-media-text',
+			'title'           => esc_html__( 'ACF Media Text', 'wds' ),
+			'description'     => esc_html__( 'A block to display media and text in a 50/50 layout.', 'wds' ),
+			'render_callback' => '',
+			'category'        => 'wds-content',
+			'icon'            => 'images-alt2',
+			'keywords'        => [ 'media', 'text', 'button', 'wds' ],
+			'mode'            => 'edit',
+			'enqueue_assets'  => '',
+			'align'           => 'wide',
+			'supports'        => $supports,
+		]
+	);
 }
 add_action( 'acf/init', 'wds_acf_blocks_init' );


### PR DESCRIPTION
Closes N/A

### Link
Link to what you built on Lab.

### Feature Description
* Added + registered ACF media text block

### Feature Screenshots
![ 2021-02-04 at 16 18 45 ](https://user-images.githubusercontent.com/12365909/106956498-aa529100-6704-11eb-9167-fcb464957ee3.png)

### Steps To Verify Feature
How will your Lead Engineer and/or stakeholder test this?

  1. Login to the WordPress admin and edit a page/post
  2. Add an ACF media text block and ensure it works

### Feature Documentation
Please link to the client facing website documentation you created in [Confluence]().

### Other
- [x] Does this PR title follow this pattern? `feature/PROJECTCODE-TICKETNUMBER-Jira-Ticket-Title`
- [ ] Is the documentation in Confluence for this feature up-to-date? N/A
- [ ] Is this feature accessible? (Section 508/WCAG 2.1AA) N/A
- [x] Does this feature pass all linting on your local? (PHPCS, ESLint, Stylelint)
- [x] Are your [text/attribute/url node](https://codex.wordpress.org/Data_Validation#Text_Nodes) escaping functions correct? e.g., `esc_html_e()`, `esc_html__()`, `esc_attr()`, `esc_url()`.
