### PR TITLE
Add WP GraphQL JWT Authentication plugin

### DIFF
--- a/composer-public.json
+++ b/composer-public.json
@@ -55,7 +55,8 @@
     "wpackagist-plugin/wordpress-seo": "^15.0",
     "wp-graphql/wp-graphql-tax-query": "^0.1.0",
     "wpackagist-plugin/add-wpgraphql-seo": "^4.11",
-    "wpackagist-plugin/block-manager": "^1.1"
+    "wpackagist-plugin/block-manager": "^1.1",
+    "wp-graphql/wp-graphql-jwt-authentication": "^0.4"
   },
   "require-dev": {
     "webdevstudios/php-coding-standards": "^1.0",

--- a/composer-public.lock
+++ b/composer-public.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adf051815144fea770edc434698d9a75",
+    "content-hash": "daa2a7b4625c04ee3dff8f0c7ffb39b4",
     "packages": [
         {
             "name": "composer/installers",
@@ -149,6 +149,56 @@
                 }
             ],
             "time": "2021-01-14T11:07:16+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "reference": "f42c9110abe98dd6cfe9053c49bc86acc70b2d23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8 <=9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "time": "2021-02-12T00:02:00+00:00"
         },
         {
             "name": "opis/json-schema",
@@ -469,6 +519,48 @@
             ],
             "description": "Advanced Custom Fields bindings for wp-graphql",
             "time": "2021-01-19T21:23:00+00:00"
+        },
+        {
+            "name": "wp-graphql/wp-graphql-jwt-authentication",
+            "version": "v0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-graphql/wp-graphql-jwt-authentication.git",
+                "reference": "7905ab9e3658e6e79be510070b9e7aaf26d47009"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-graphql/wp-graphql-jwt-authentication/zipball/7905ab9e3658e6e79be510070b9e7aaf26d47009",
+                "reference": "7905ab9e3658e6e79be510070b9e7aaf26d47009",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "^5.0"
+            },
+            "require-dev": {
+                "lucatume/wp-browser": ">=2.2.1 <2.2.8"
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "psr-4": {
+                    "WPGraphQL\\JWT_Authentication\\": "src/"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0+"
+            ],
+            "authors": [
+                {
+                    "name": "jasonbahl",
+                    "email": "jasonbahl@mac.com"
+                }
+            ],
+            "description": "JWT Authentication for WPGraphQL",
+            "time": "2020-05-04T21:48:10+00:00"
         },
         {
             "name": "wp-graphql/wp-graphql-tax-query",

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
     "wpackagist-plugin/gutenberg": "^10.0",
     "wpackagist-plugin/lazy-blocks": "^2.3",
     "wpackagist-plugin/wp-graphql": "^1.1",
-    "wpackagist-plugin/wp-search-with-algolia": "^1.7"
+    "wpackagist-plugin/wp-search-with-algolia": "^1.7",
+    "wp-graphql/wp-graphql-jwt-authentication": "^0.4"
   },
   "require-dev": {
     "webdevstudios/php-coding-standards": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b78a9bfb08a9653329121a4ab5237f8",
+    "content-hash": "f843b0593a80936db0c265a1ec95f5b9",
     "packages": [
         {
             "name": "composer/installers",
@@ -1466,7 +1466,7 @@
                 "type": "tar",
                 "url": "https://packages.wdslab.com/dist/webdevstudios/mu-autoload/webdevstudios-mu-autoload-v1.5-429874.tar",
                 "reference": "6cd400dc39043901c2c92b3c8ebe2fdc4ce17f91",
-                "shasum": "6f371a7d3374d88877518a41849e4213d2b8477e"
+                "shasum": "11a2757d8ea27a0444557381052eca40a8827958"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1497,7 +1497,7 @@
                 "type": "tar",
                 "url": "https://packages.wdslab.com/dist/webdevstudios/sso/webdevstudios-sso-2.0.1-c7f0f6.tar",
                 "reference": "86259b5e6f788189cab1760d257416f6e76ff226",
-                "shasum": "d32c0c90a6804d306f7180d8ca047da5c7162361"
+                "shasum": "d3a9b28480bbb5bd531aef536897ef0d15d66ce2"
             },
             "require": {
                 "composer/installers": "~1.0",
@@ -1544,7 +1544,7 @@
                 "type": "tar",
                 "url": "https://packages.wdslab.com/dist/webdevstudios/sso-addon/webdevstudios-sso-addon-1.0.1-d9b41f.tar",
                 "reference": "05c879f9bf605050930473842fb3313b21b48588",
-                "shasum": "88e98d204460db969207d7f7be8e8914cdcb1fcf"
+                "shasum": "541e6ccd07fe9960b9e0128f20eaf45cc821c4a2"
             },
             "require": {
                 "composer/installers": "~1.0",
@@ -1632,6 +1632,48 @@
             ],
             "description": "Advanced Custom Fields bindings for wp-graphql",
             "time": "2021-01-19T21:23:00+00:00"
+        },
+        {
+            "name": "wp-graphql/wp-graphql-jwt-authentication",
+            "version": "v0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-graphql/wp-graphql-jwt-authentication.git",
+                "reference": "7905ab9e3658e6e79be510070b9e7aaf26d47009"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-graphql/wp-graphql-jwt-authentication/zipball/7905ab9e3658e6e79be510070b9e7aaf26d47009",
+                "reference": "7905ab9e3658e6e79be510070b9e7aaf26d47009",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "^5.0"
+            },
+            "require-dev": {
+                "lucatume/wp-browser": ">=2.2.1 <2.2.8"
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "psr-4": {
+                    "WPGraphQL\\JWT_Authentication\\": "src/"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0+"
+            ],
+            "authors": [
+                {
+                    "name": "jasonbahl",
+                    "email": "jasonbahl@mac.com"
+                }
+            ],
+            "description": "JWT Authentication for WPGraphQL",
+            "time": "2020-05-04T21:48:10+00:00"
         },
         {
             "name": "wp-graphql/wp-graphql-tax-query",


### PR DESCRIPTION
### Description
Related ticket: https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/233

This PR adds [WP GraphQL JWT Authentication plugin](https://github.com/wp-graphql/wp-graphql-jwt-authentication) in our WP backend.

The plugin extends WP GraphQL to allow registration / login.

### Feature Documentation

For the actual plugin installation / setup, please refer to https://github.com/wp-graphql/wp-graphql-jwt-authentication