### PR TITLE
Make users visible to public in GraphQL context

### DIFF
--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -103,8 +103,6 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	/**
 	 * Allow access to additional fields via non-authed GraphQL request.
 	 *
-	 * @author WebDevStudios
-	 * @since 1.0
 	 * @param  array  $fields     The fields to allow when the data is designated as restricted to the current user.
 	 * @param  string $model_name Name of the model the filter is currently being executed in.
 	 * @return array                   Allowed fields.
@@ -143,6 +141,8 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	/**
 	 * Make all Users public including in non-authenticated WPGraphQL requests.
 	 *
+	 * @author WebDevStudios
+	 * @since 1.0
 	 * @param string  $visibility
 	 * @param string  $model_name
 	 * @param mixed   $data

--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -120,4 +120,38 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	}
 	add_filter( 'graphql_allowed_fields_on_restricted_type', 'wds_graphql_allowed_fields', 10, 6 );
 
+	/**
+	 * Include users without published posts in SQL query
+	 *
+	 * @param array                      $query_args          The query args to be used with the executable query to get data.
+	 * @param AbstractConnectionResolver $connection_resolver Instance of the connection resolver
+	 * @return void
+	 */
+	function wds_public_unpublished_users( array $query_args, \WPGraphQL\Data\Connection\AbstractConnectionResolver $connection_resolver ) {
+		if ( $connection_resolver instanceof \WPGraphQL\Data\Connection\UserConnectionResolver ) {
+			unset( $query_args['has_published_posts'] );
+		}
+
+		return $query_args;
+	}
+	add_filter( 'graphql_connection_query_args', 'wds_public_unpublished_users', 10, 2 );
+
+	/**
+	 * Make all Users public including in non-authenticated WPGraphQL requests.
+	 *
+	 * @param string  $visibility
+	 * @param string  $model_name
+	 * @param mixed   $data
+	 * @param integer $owner
+	 * @param WP_User $current_user
+	 * @return void
+	 */
+	function wds_public_users( string $visibility, string $model_name ) {
+		if ( 'UserObject' === $model_name ) {
+			$visibility = 'public';
+		}
+
+		return $visibility;
+	}
+	add_filter( 'graphql_object_visibility', 'wds_public_users', 10, 2 );
 }

--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -103,6 +103,8 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	/**
 	 * Allow access to additional fields via non-authed GraphQL request.
 	 *
+	 * @author WebDevStudios
+	 * @since 1.0
 	 * @param  array  $fields     The fields to allow when the data is designated as restricted to the current user.
 	 * @param  string $model_name Name of the model the filter is currently being executed in.
 	 * @return array                   Allowed fields.
@@ -121,8 +123,10 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	add_filter( 'graphql_allowed_fields_on_restricted_type', 'wds_graphql_allowed_fields', 10, 6 );
 
 	/**
-	 * Include users without published posts in SQL query
+	 * Include users without published posts in SQL query.
 	 *
+	 * @author WebDevStudios
+	 * @since 1.0
 	 * @param array                      $query_args          The query args to be used with the executable query to get data.
 	 * @param AbstractConnectionResolver $connection_resolver Instance of the connection resolver
 	 * @return void


### PR DESCRIPTION
### Issue
The issue is that we are receiving `null` as `author` on comments from users without published post. This is related to https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/233

### Feature Description

Per WP GraphQL's docs

> WPGraphQL follows WordPress access control rights, and only exposes data publicly that WordPress already exposes publicly. Users that have published posts are considered public entities in WordPress. Users that have not published posts are considered private and will not be included in public GraphQL requests, but will be included in GraphQL requests made by authenticated users with proper capabilities to see the users.

Reference: https://www.wpgraphql.com/docs/users/

This PR make all users public.

### Screenshots

**How comments look like in the backend**
![Screen Shot 2021-03-12 at 9 37 00 PM](https://user-images.githubusercontent.com/5747475/110947620-5aa65b80-837b-11eb-9eef-68f7369c7a7e.png)

**WP GraphQL response prior to this PR**
![Screen Shot 2021-03-12 at 9 39 56 PM](https://user-images.githubusercontent.com/5747475/110947887-ad801300-837b-11eb-9e02-95a36a095de5.png)

Notice that `null` is returned instead of _**John Doe**_ 

```
"node": {
    "content": "<p>Example comment from a new user.<\/p>\n",
    "author": {
        "node": null
    }
}
```

**WP GraphQL with this PR code changes**
![Screen Shot 2021-03-12 at 9 45 20 PM](https://user-images.githubusercontent.com/5747475/110948525-6cd4c980-837c-11eb-9b49-6f7c1274d177.png)

### Steps To Verify Feature
  1. Create a new WP User via WP Dashboad > Users.
  1. Switch to any default theme first so you can comment to a blog post via WP site (not from NextJS frontend).
  1. Perform a non-authenticated GraphQL request that returns the comment. You should see something like the second screenshot above.
  1. Switch to WDS Headless Theme then perform again the same non-authenticated GraphQL request. You should now see the correct `author` instead of `null`.

**Note:** Do not use the GraphiQL IDE on WP Dashboard since it will be authenticated. 