### PR TITLE
feature/293-dynamic-archive-meta-title

### DIFF
--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -176,6 +176,7 @@ if ( class_exists( 'WPGraphQL' ) ) {
 				'metaDesc'           => [ 'type' => 'String' ],
 				'metaRobotsNoindex'  => [ 'type' => 'String' ],
 				'metaRobotsNofollow' => [ 'type' => 'String' ],
+				'canonical'          => [ 'type' => 'String' ],
 			],
 		] );
 
@@ -229,6 +230,7 @@ if ( class_exists( 'WPGraphQL' ) ) {
 							'metaDesc'           => wp_gql_seo_format_string( $description ),
 							'metaRobotsNoindex'  => $archive_seo->robots['index'],
 							'metaRobotsNofollow' => $archive_seo->robots['follow'],
+							'canonical'          => $archive_seo->canonical,
 						];
 					},
 				]

--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -166,6 +166,7 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	 *
 	 * @author WebDevStudios
 	 * @since 1.0
+	 * @return void
 	 */
 	function wds_register_archive_seo() {
 		register_graphql_object_type( 'ArchiveSeo', [
@@ -184,7 +185,7 @@ if ( class_exists( 'WPGraphQL' ) ) {
 		], 'objects' );
 
 		// Bail if we don't have an array of post types.
-		if ( empty( $post_types )  || ! is_array( $post_types ) ) {
+		if ( empty( $post_types ) || ! is_array( $post_types ) ) {
 			return;
 		}
 
@@ -201,9 +202,13 @@ if ( class_exists( 'WPGraphQL' ) ) {
 				'archiveSeo',
 				[
 					'type'        => 'ArchiveSeo',
-					'description' => __( "The Yoast SEO data of the {$post_type_object->label} post type archive", 'wds' ),
+					'description' => sprintf(
+						/* translators: the post type label. */
+						__( 'The Yoast SEO data of the %s post type archive', 'wds' ),
+						$post_type_object->label
+					),
 					'resolve'     => function () use ( $post_type, $post_type_object ) {
-						// https://developer.yoast.com/blog/yoast-seo-14-0-using-yoast-seo-surfaces/
+						// Surface info: https://developer.yoast.com/blog/yoast-seo-14-0-using-yoast-seo-surfaces/.
 						/* We would ideally use this surface to determine meta title and desc, but the surface is not pulling the correct meta for those fields (as of Yoast 15.9.2, it seems to be pulling some default archive meta title and a blank desc). */
 						$archive_seo = YoastSEO()->meta->for_post_type_archive( $post_type );
 

--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -160,4 +160,75 @@ if ( class_exists( 'WPGraphQL' ) ) {
 		return $visibility;
 	}
 	add_filter( 'graphql_object_visibility', 'wds_public_users', 10, 2 );
+
+	/**
+	 * Add archive SEO field to CPT archive queries in GraphQL.
+	 *
+	 * @author WebDevStudios
+	 * @since 1.0
+	 */
+	function wds_register_archive_seo() {
+		register_graphql_object_type( 'ArchiveSeo', [
+			'description' => esc_html__( 'Archive SEO data', 'wds' ),
+			'fields'      => [
+				'title'              => [ 'type' => 'String' ],
+				'metaDesc'           => [ 'type' => 'String' ],
+				'metaRobotsNoindex'  => [ 'type' => 'String' ],
+				'metaRobotsNofollow' => [ 'type' => 'String' ],
+			],
+		] );
+
+		// Get post types that support archives (will not include "post" PT).
+		$post_types = get_post_types( [
+			'has_archive' => true,
+		], 'objects' );
+
+		// Bail if we don't have an array of post types.
+		if ( empty( $post_types )  || ! is_array( $post_types ) ) {
+			return;
+		}
+
+		// Register GraphQL field on each post type's plural/archive connection.
+		foreach ( $post_types as $post_type => $post_type_object ) {
+			if ( ! $post_type_object->show_in_graphql || ! $post_type_object->graphql_single_name ) {
+				break;
+			}
+
+			$pt_singular = ucfirst( $post_type_object->graphql_single_name );
+
+			register_graphql_field(
+				"RootQueryTo{$pt_singular}Connection",
+				'archiveSeo',
+				[
+					'type'        => 'ArchiveSeo',
+					'description' => __( "The Yoast SEO data of the {$post_type_object->label} post type archive", 'wds' ),
+					'resolve'     => function () use ( $post_type, $post_type_object ) {
+						// https://developer.yoast.com/blog/yoast-seo-14-0-using-yoast-seo-surfaces/
+						/* We would ideally use this surface to determine meta title and desc, but the surface is not pulling the correct meta for those fields (as of Yoast 15.9.2, it seems to be pulling some default archive meta title and a blank desc). */
+						$archive_seo = YoastSEO()->meta->for_post_type_archive( $post_type );
+
+						// Retrieve Yoast SEO options for archive title and desc instead.
+						$wpseo_options = WPSEO_Options::get_instance();
+						$title         = $wpseo_options->get( "title-ptarchive-{$post_type}" );
+						$description   = $wpseo_options->get( "metadesc-ptarchive-{$post_type}", $archive_seo->description );
+
+						/* Manually replace title vars that won't get caught in next step (e.g., pt_single, pt_plural) -- these appear to be "advanced" vars that require a single post to be passed, rather than a post type object. */
+						$title = str_ireplace( '%%pt_single%%', $post_type_object->labels->singular_name, $title );
+						$title = str_ireplace( '%%pt_plural%%', $post_type_object->labels->name, $title );
+
+						// Replace standard title vars with post type object.
+						$title = wpseo_replace_vars( $title, $post_type_object );
+
+						return [
+							'title'              => wp_gql_seo_format_string( $title ?? $archive_seo->title ),
+							'metaDesc'           => wp_gql_seo_format_string( $description ),
+							'metaRobotsNoindex'  => $archive_seo->robots['index'],
+							'metaRobotsNofollow' => $archive_seo->robots['follow'],
+						];
+					},
+				]
+			);
+		}
+	}
+	add_action( 'graphql_register_types', 'wds_register_archive_seo' );
 }


### PR DESCRIPTION
References https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/293

### Link

Link to what you built on WP Engine.

### Feature Description

Adds `archiveSeo` field to top-level of all CPT archive queries (e.g., `teams {}`).
Adds handling for the following archive SEO fields:
- `metaDesc`
- `metaRobotsNofollow`
- `metaRobotsNoindex`
- `canonical`
- `title` - Adds special handling to ensure post type singular/plural vars are replaced properly

### Feature Screenshots

![Screen Shot 2021-03-31 at 11 43 04 AM](https://user-images.githubusercontent.com/36422618/113187645-5355cd80-9216-11eb-999f-be818f70a9cb.png)

### Steps To Verify Feature

How will your Lead Engineer and/or stakeholder test this?

1.
2.
3.

### Other

- [x] Does this PR title follow this pattern? `feature/TICKETNUMBER-Github-Issue-Title`
- [ ] Is the documentation in Confluence for this feature up-to-date?
- [ ] Is this feature accessible? (Section 508/WCAG 2.1AA)
- [x] Does this feature pass all linting on your local?
- [ ] Are your [text/attribute/url node](https://codex.wordpress.org/Data_Validation#Text_Nodes) escaping functions correct? e.g., `esc_html_e()`, `esc_html__()`, `esc_attr()`, `esc_url()`.
