### PR TITLE
feature/369-code-reorganization-gf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "deliciousbrains-plugin/wp-migrate-db-pro": "^1.9",
     "deliciousbrains-plugin/wp-migrate-db-pro-cli": "^1.3",
     "deliciousbrains-plugin/wp-migrate-db-pro-media-files": "^1.4",
-    "harness-software/wp-graphql-gravity-forms": "^0.3",
+    "harness-software/wp-graphql-gravity-forms": "^0.4",
     "pristas-peter/wp-graphql-gutenberg": "^0.3",
     "webdevstudios/advanced-custom-fields-pro": "^5.9",
     "webdevstudios/gravityforms": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d01dc0e42707021340ef39d047a612f",
+    "content-hash": "aac349bf39a825d22ce0b04d560973d7",
     "packages": [
         {
             "name": "composer/installers",
@@ -155,7 +155,8 @@
             "version": "1.9.14",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro/deliciousbrains-plugin-wp-migrate-db-pro-1.9.14.tar"
+                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro/deliciousbrains-plugin-wp-migrate-db-pro-1.9.14.tar",
+                "shasum": "933a66f29103d565ece62636f3bd08e39d01bd42"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -167,7 +168,8 @@
             "version": "1.3.5",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro-cli/deliciousbrains-plugin-wp-migrate-db-pro-cli-1.3.5.tar"
+                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro-cli/deliciousbrains-plugin-wp-migrate-db-pro-cli-1.3.5.tar",
+                "shasum": "7ec81ae132f8f5ae2562eaf0ec1e52e4940ceb3c"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -179,7 +181,8 @@
             "version": "1.4.16",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro-media-files/deliciousbrains-plugin-wp-migrate-db-pro-media-files-1.4.16.tar"
+                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro-media-files/deliciousbrains-plugin-wp-migrate-db-pro-media-files-1.4.16.tar",
+                "shasum": "b2e706ad5038a6dde861c1bbaaae1bf6e2f77788"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -613,23 +616,24 @@
         },
         {
             "name": "harness-software/wp-graphql-gravity-forms",
-            "version": "0.3.1",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/harness-software/wp-graphql-gravity-forms.git",
-                "reference": "793bd15db3d2df397ae59a14a33d33da6787ffad"
+                "reference": "df001611a97eab8f7acd7315ae90f0ce5c34f373"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/harness-software/wp-graphql-gravity-forms/zipball/793bd15db3d2df397ae59a14a33d33da6787ffad",
-                "reference": "793bd15db3d2df397ae59a14a33d33da6787ffad",
+                "url": "https://api.github.com/repos/harness-software/wp-graphql-gravity-forms/zipball/df001611a97eab8f7acd7315ae90f0ce5c34f373",
+                "reference": "df001611a97eab8f7acd7315ae90f0ce5c34f373",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4"
             },
             "require-dev": {
-                "codeception/module-asserts": "^1.0",
+                "codeception/lib-innerbrowser": "^1.0",
+                "codeception/module-asserts": "^1.1",
                 "codeception/module-cli": "^1.0",
                 "codeception/module-db": "^1.0",
                 "codeception/module-filesystem": "^1.0",
@@ -639,13 +643,13 @@
                 "codeception/util-universalframework": "^1.0",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
                 "lucatume/wp-browser": "^3.0",
-                "phpcompatibility/phpcompatibility-wp": "2.1.0",
+                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^0.12.64",
+                "phpstan/phpstan": "^0.12",
                 "phpunit/phpunit": "^9.5",
                 "simpod/php-coveralls-mirror": "^3.0",
                 "squizlabs/php_codesniffer": "^3.5.8",
-                "szepeviktor/phpstan-wordpress": "^0.7.1",
+                "szepeviktor/phpstan-wordpress": "^0.7",
                 "wp-coding-standards/wpcs": "^2.3"
             },
             "type": "wordpress-plugin",
@@ -662,10 +666,13 @@
                 {
                     "name": "Kellen Mace",
                     "email": "kellen@harnessup.com"
+                },
+                {
+                    "name": "Dovid Levine"
                 }
             ],
             "description": "WPGraphQL for Gravity Forms",
-            "time": "2021-03-18T16:43:25+00:00"
+            "time": "2021-04-10T04:06:34+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1449,7 +1456,8 @@
             "version": "5.9.5",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/webdevstudios/advanced-custom-fields-pro/webdevstudios-advanced-custom-fields-pro-5.9.5.tar"
+                "url": "https://packages.wdslab.com/dist/webdevstudios/advanced-custom-fields-pro/webdevstudios-advanced-custom-fields-pro-5.9.5.tar",
+                "shasum": "1eff76c921d1665d98a8391203494d089c7d578b"
             },
             "require": {
                 "composer/installers": "^1.0"
@@ -1491,7 +1499,8 @@
             "dist": {
                 "type": "tar",
                 "url": "https://packages.wdslab.com/dist/webdevstudios/mu-autoload/webdevstudios-mu-autoload-v1.5-429874.tar",
-                "reference": "6cd400dc39043901c2c92b3c8ebe2fdc4ce17f91"
+                "reference": "6cd400dc39043901c2c92b3c8ebe2fdc4ce17f91",
+                "shasum": "6f371a7d3374d88877518a41849e4213d2b8477e"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1600,7 +1609,8 @@
             "version": "15.9.2",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/webdevstudios/wordpress-seo-premium/webdevstudios-wordpress-seo-premium-15.9.2.tar"
+                "url": "https://packages.wdslab.com/dist/webdevstudios/wordpress-seo-premium/webdevstudios-wordpress-seo-premium-15.9.2.tar",
+                "shasum": "306d1b42da9194aacd1f2b9e8696122387cd6786"
             },
             "require": {
                 "composer/installers": "^1.0"


### PR DESCRIPTION
References https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/369

### Description

Bumps [WP GraphQL Gravity Forms](https://github.com/harness-software/wp-graphql-gravity-forms) to v0.4.1.

**Note: This should NOT be merged until the corresponding [FE PR](https://github.com/WebDevStudios/nextjs-wordpress-starter/pull/379) is ready to merge, as v0.4 introduces breaking changes (but this PR should be merged first).**

### Steps To Verify Feature

Ensure GF forms still display/function on the FE.
