### PR TITLE
Feature/383 todos paragraph

### DIFF
--- a/themes/wds_headless/functions.php
+++ b/themes/wds_headless/functions.php
@@ -57,6 +57,15 @@ function wds_theme_setup() {
 	// Disable background color gradient presets.
 	// See note above re: 'editor-color-palette'.
 	add_theme_support( 'editor-gradient-presets', [] );
+
+	// Reset available font size presets to only "normal" (16px).
+	add_theme_support( 'editor-font-sizes', [
+		[
+			'name' => 'Normal',
+			'size' => 16,
+			'slug' => 'normal',
+		],
+	] );
 }
 add_action( 'after_setup_theme', 'wds_theme_setup' );
 

--- a/themes/wds_headless/functions.php
+++ b/themes/wds_headless/functions.php
@@ -50,10 +50,6 @@ function wds_theme_setup() {
 		]
 	);
 
-	// Disable color palette presets.
-	// This is disabled as there is seemingly no clean way to pass the palette color hex values to the FE instead of the arbitrary color names. In the future, we can re-enable the palette if we define a custom palette in the theme and again as a config object on the FE (e.g., under /lib/wordpress/_config/).
-	add_theme_support( 'editor-color-palette' );
-
 	// Disable background color gradient presets.
 	// See note above re: 'editor-color-palette'.
 	add_theme_support( 'editor-gradient-presets', [] );

--- a/themes/wds_headless/functions.php
+++ b/themes/wds_headless/functions.php
@@ -49,6 +49,14 @@ function wds_theme_setup() {
 			'primary-menu' => esc_html__( 'Primary Menu' ),
 		]
 	);
+
+	// Disable color palette presets.
+	// This is disabled as there is seemingly no clean way to pass the palette color hex values to the FE instead of the arbitrary color names. In the future, we can re-enable the palette if we define a custom palette in the theme and again as a config object on the FE (e.g., under /lib/wordpress/_config/).
+	add_theme_support( 'editor-color-palette' );
+
+	// Disable background color gradient presets.
+	// See note above re: 'editor-color-palette'.
+	add_theme_support( 'editor-gradient-presets', [] );
 }
 add_action( 'after_setup_theme', 'wds_theme_setup' );
 

--- a/themes/wds_headless/js/blocks.js
+++ b/themes/wds_headless/js/blocks.js
@@ -1,3 +1,7 @@
+const { validateThemeColors } = wp.blockEditor;
+const { useEffect } = wp.element;
+const { addFilter } = wp.hooks;
+
 /**
  * Additional Gutenberg block functionality.
  *
@@ -14,3 +18,82 @@ wp.domReady(() => {
 		label: "Full Width",
 	});
 });
+
+addFilter(
+	"blocks.registerBlockType",
+	"wds/filterParagraphBlockAttrs1",
+	wdsAddColorPaletteHexValues
+);
+
+/**
+ * Filter block registration to add custom color attributes to paragraph block.
+ *
+ * TODO: Extend this to apply to other blocks that use the color palette.
+ *
+ * @param {object} settings Block settings config.
+ * @param {string} name     Block name.
+ * @return {object}         Block settings config.
+ */
+function wdsAddColorPaletteHexValues(settings, name) {
+	if ("core/paragraph" !== name) {
+		return settings;
+	}
+
+	// Add hex color attributes.
+	settings.attributes = {
+		...settings.attributes,
+		backgroundColorHex: {
+			type: "string",
+			default: "",
+		},
+		textColorHex: {
+			type: "string",
+			default: "",
+		},
+	};
+
+	return {
+		...settings,
+		edit(props) {
+			const {
+				attributes: { backgroundColor, textColor },
+			} = props;
+
+			useEffect(() => {
+				// Note: This may not work as expected if a custom theme palette has been set.
+				// In that case, this filter may need to be customized.
+				const defaultColors = validateThemeColors();
+
+				// Check for presence of background color attr.
+				if (backgroundColor) {
+					// Get color object by slug.
+					const backgroundColorObj = defaultColors.filter(
+						(color) => color.slug === backgroundColor
+					);
+
+					// Retrieve color hex value.
+					props.attributes.backgroundColorHex =
+						backgroundColorObj?.[0]?.color || null;
+				} else {
+					props.attributes.backgroundColorHex = "";
+				}
+
+				// Check for presence of text color attr.
+				if (textColor) {
+					// Get color object by slug.
+					const textColorObj = defaultColors.filter(
+						(color) => color.slug === textColor
+					);
+
+					// Retrieve color hex value.
+					props.attributes.textColorHex =
+						textColorObj?.[0]?.color || null;
+				} else {
+					props.attributes.textColorHex = "";
+				}
+			}, [backgroundColor, textColor]);
+
+			return settings.edit(props);
+		},
+	};
+}


### PR DESCRIPTION
### Description

Removed font size presets, leaving only "normal" (16px).
Removed gradient color palette presets (this can be re-added later by customizing the `wdsAddColorPaletteHexValues` function to handle gradients).
Added filter to pass hex values of (solid) color palette presets as extra attributes.

### Screenshots

#### Reduced font-size presets
![Screen Shot 2021-04-28 at 2 41 47 PM](https://user-images.githubusercontent.com/36422618/116469832-e0993b80-a82f-11eb-81c6-6e3010a010bc.png)

#### New color hex attrs
![Screen Shot 2021-04-28 at 2 44 49 PM](https://user-images.githubusercontent.com/36422618/116470192-4d143a80-a830-11eb-91c3-8b80c7728634.png)

#### FE display with pre-defined and custom colors
![Screen Shot 2021-04-28 at 2 44 06 PM](https://user-images.githubusercontent.com/36422618/116470195-4d143a80-a830-11eb-85ca-2c0140362032.png)

### Steps To Verify Feature

1. Edit any post (e.g., https://nextjsdevstart.wpengine.com/wp-admin/post.php?post=421&action=edit)
2. Add a paragraph block with font size & color settings
3. Font size options should be default, normal, custom
4. With FE PR [#395](https://github.com/WebDevStudios/nextjs-wordpress-starter/pull/395) checked out, view the post on the FE to see the color settings applied
