### PR TITLE
Feature/380 gf upload support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "deliciousbrains-plugin/wp-migrate-db-pro": "^1.9",
     "deliciousbrains-plugin/wp-migrate-db-pro-cli": "^1.3",
     "deliciousbrains-plugin/wp-migrate-db-pro-media-files": "^1.4",
+    "dre1080/wp-graphql-upload": "^0.1",
     "harness-software/wp-graphql-gravity-forms": "^0.3",
     "pristas-peter/wp-graphql-gutenberg": "^0.3",
     "webdevstudios/advanced-custom-fields-pro": "^5.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d01dc0e42707021340ef39d047a612f",
+    "content-hash": "bc5faeb2bb15fa0bc698c116b892423d",
     "packages": [
         {
             "name": "composer/installers",
@@ -157,7 +157,8 @@
             "version": "1.9.14",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro/deliciousbrains-plugin-wp-migrate-db-pro-1.9.14.tar"
+                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro/deliciousbrains-plugin-wp-migrate-db-pro-1.9.14.tar",
+                "shasum": "933a66f29103d565ece62636f3bd08e39d01bd42"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -181,12 +182,65 @@
             "version": "1.4.16",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro-media-files/deliciousbrains-plugin-wp-migrate-db-pro-media-files-1.4.16.tar"
+                "url": "https://packages.wdslab.com/dist/deliciousbrains-plugin/wp-migrate-db-pro-media-files/deliciousbrains-plugin-wp-migrate-db-pro-media-files-1.4.16.tar",
+                "shasum": "b2e706ad5038a6dde861c1bbaaae1bf6e2f77788"
             },
             "require": {
                 "composer/installers": "~1.0"
             },
             "type": "wordpress-plugin"
+        },
+        {
+            "name": "dre1080/wp-graphql-upload",
+            "version": "v0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dre1080/wp-graphql-upload.git",
+                "reference": "6f1def0449b085b0c0b3dc30dd5f4c58157ba408"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dre1080/wp-graphql-upload/zipball/6f1def0449b085b0c0b3dc30dd5f4c58157ba408",
+                "reference": "6f1def0449b085b0c0b3dc30dd5f4c58157ba408",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "phpcompatibility/phpcompatibility-wp": "*",
+                "phpunit/phpunit": "^7",
+                "squizlabs/php_codesniffer": "*",
+                "webonyx/graphql-php": "^14.5"
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "psr-4": {
+                    "WPGraphQL\\Upload\\": "src/"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "ando",
+                    "email": "lifeandcoding@gmail.com"
+                }
+            ],
+            "description": "Adds file upload support to the WP GraphQL Plugin.",
+            "keywords": [
+                "graphql",
+                "upload",
+                "wordpress",
+                "wp-graphql"
+            ],
+            "time": "2021-02-06T17:30:04+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -1451,7 +1505,8 @@
             "version": "5.9.5",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/webdevstudios/advanced-custom-fields-pro/webdevstudios-advanced-custom-fields-pro-5.9.5.tar"
+                "url": "https://packages.wdslab.com/dist/webdevstudios/advanced-custom-fields-pro/webdevstudios-advanced-custom-fields-pro-5.9.5.tar",
+                "shasum": "1eff76c921d1665d98a8391203494d089c7d578b"
             },
             "require": {
                 "composer/installers": "^1.0"
@@ -1493,7 +1548,8 @@
             "dist": {
                 "type": "tar",
                 "url": "https://packages.wdslab.com/dist/webdevstudios/mu-autoload/webdevstudios-mu-autoload-v1.5-429874.tar",
-                "reference": "6cd400dc39043901c2c92b3c8ebe2fdc4ce17f91"
+                "reference": "6cd400dc39043901c2c92b3c8ebe2fdc4ce17f91",
+                "shasum": "6f371a7d3374d88877518a41849e4213d2b8477e"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1602,7 +1658,8 @@
             "version": "15.9.2",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/webdevstudios/wordpress-seo-premium/webdevstudios-wordpress-seo-premium-15.9.2.tar"
+                "url": "https://packages.wdslab.com/dist/webdevstudios/wordpress-seo-premium/webdevstudios-wordpress-seo-premium-15.9.2.tar",
+                "shasum": "306d1b42da9194aacd1f2b9e8696122387cd6786"
             },
             "require": {
                 "composer/installers": "^1.0"

--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -304,7 +304,7 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	 * @param array $fields The array of fields for the FieldValuesInput object.
 	 * @return array        The filtered array of fields for the FieldValuesInput object.
 	 */
-	function wds_add_file_upload_field( $fields ) {
+	function wds_add_file_upload_field( array $fields ) {
 		$fields['fileUploadValues'] = [
 			'type'        => 'Upload',
 			'description' => esc_html__( 'The form field values for FileUpload fields.', 'wds' ),

--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -238,4 +238,22 @@ if ( class_exists( 'WPGraphQL' ) ) {
 		}
 	}
 	add_action( 'graphql_register_types', 'wds_register_archive_seo' );
+
+	/**
+	 * Add file upload field to GF FieldValuesInput.
+	 *
+	 * @author WebDevStudios
+	 * @since 1.0
+	 * @param array $input_fields The array of fields for the FieldValuesInput object.
+	 * @return array              The filtered array of fields for the FieldValuesInput object.
+	 */
+	function wds_add_file_upload_field( $input_fields ) {
+		$input_fields['fileUploadValues'] = [
+			'type'        => 'Upload',
+			'description' => esc_html__( 'The form field values for FileUpload fields.', 'wds' ),
+		];
+
+		return $input_fields;
+	}
+	add_filter( 'graphql_fieldValuesInput_fields', 'wds_add_file_upload_field' );
 }

--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -242,7 +242,8 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	}
 	add_action( 'graphql_register_types', 'wds_register_archive_seo' );
 
-	/* Edit the error messages on user registration.
+	/**
+	 * Edit the error messages on user registration.
 	 *
 	 * @author WebDevStudios
 	 * @since 1.0

--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -244,16 +244,16 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	 *
 	 * @author WebDevStudios
 	 * @since 1.0
-	 * @param array $input_fields The array of fields for the FieldValuesInput object.
-	 * @return array              The filtered array of fields for the FieldValuesInput object.
+	 * @param array $fields The array of fields for the FieldValuesInput object.
+	 * @return array        The filtered array of fields for the FieldValuesInput object.
 	 */
-	function wds_add_file_upload_field( $input_fields ) {
-		$input_fields['fileUploadValues'] = [
+	function wds_add_file_upload_field( $fields ) {
+		$fields['fileUploadValues'] = [
 			'type'        => 'Upload',
 			'description' => esc_html__( 'The form field values for FileUpload fields.', 'wds' ),
 		];
 
-		return $input_fields;
+		return $fields;
 	}
 	add_filter( 'graphql_fieldValuesInput_fields', 'wds_add_file_upload_field' );
 }

--- a/themes/wds_headless/inc/wp-graphql.php
+++ b/themes/wds_headless/inc/wp-graphql.php
@@ -243,57 +243,57 @@ if ( class_exists( 'WPGraphQL' ) ) {
 	add_action( 'graphql_register_types', 'wds_register_archive_seo' );
 
 	/* Edit the error messages on user registration.
-	*
-	* @author WebDevStudios
-	* @since 1.0
-	* @param \WP_Error $errors A WP_Error object containing any errors encountered during registration.
-	* @return \WP_Error
-	*/
-   function wds_filter_registration_errors( \WP_Error $errors ) {
-	   if ( ! $errors->has_errors() ) {
-		   return $errors;
-	   }
+	 *
+	 * @author WebDevStudios
+	 * @since 1.0
+	 * @param \WP_Error $errors A WP_Error object containing any errors encountered during registration.
+	 * @return \WP_Error
+	 */
+	function wds_filter_registration_errors( \WP_Error $errors ) {
+		if ( ! $errors->has_errors() ) {
+			return $errors;
+		}
 
-	   $new_errors_obj = new \WP_Error();
-	   foreach ( $errors->get_error_codes() as $error_code ) {
-		   switch ( $error_code ) {
-			   case 'empty_username':
-				   $error_msg = esc_html__( 'Please enter a username.', 'wds' );
-				   break;
-			   case 'invalid_username':
-				   $error_msg = esc_html__( 'This username is invalid because it uses illegal characters. Please enter a valid username.', 'wds' );
-				   break;
-			   case 'username_exists':
-				   $error_msg = esc_html__( 'This username is already registered. Please choose another one.', 'wds' );
-				   break;
-			   case 'empty_email':
-				   $error_msg = esc_html__( 'Please enter your email address.', 'wds' );
-				   break;
-			   case 'invalid_email':
-				   $error_msg = esc_html__( 'Please enter a valid email address.', 'wds' );
-				   break;
-			   case 'email_exists':
-				   $error_msg = esc_html__( 'This username is already registered. Please choose another one.', 'wds' );
-				   break;
-			   default:
-				   $error_msg = esc_html__( 'Registration failed. Please contact the admin.', 'wds' );
-				   break;
-		   }
-		   $new_errors_obj->add( $error_code, $error_msg );
-	   }
-	   return $new_errors_obj;
-   }
+		$new_errors_obj = new \WP_Error();
+		foreach ( $errors->get_error_codes() as $error_code ) {
+			switch ( $error_code ) {
+				case 'empty_username':
+					$error_msg = esc_html__( 'Please enter a username.', 'wds' );
+					break;
+				case 'invalid_username':
+					$error_msg = esc_html__( 'This username is invalid because it uses illegal characters. Please enter a valid username.', 'wds' );
+					break;
+				case 'username_exists':
+					$error_msg = esc_html__( 'This username is already registered. Please choose another one.', 'wds' );
+					break;
+				case 'empty_email':
+					$error_msg = esc_html__( 'Please enter your email address.', 'wds' );
+					break;
+				case 'invalid_email':
+					$error_msg = esc_html__( 'Please enter a valid email address.', 'wds' );
+					break;
+				case 'email_exists':
+					$error_msg = esc_html__( 'This username is already registered. Please choose another one.', 'wds' );
+					break;
+				default:
+					$error_msg = esc_html__( 'Registration failed. Please contact the admin.', 'wds' );
+					break;
+			}
+			$new_errors_obj->add( $error_code, $error_msg );
+		}
+		return $new_errors_obj;
+	}
 
-   /**
-	* Add hooks that should only occur in the context of a GraphQL Request.
-	*
-	* @author WebDevStudios
-	* @since 1.0
-	*/
-   function wds_graphql_request_init() {
-	   add_filter( 'registration_errors', 'wds_filter_registration_errors' );
-   }
-   add_action( 'init_graphql_request', 'wds_graphql_request_init' );
+	/**
+	 * Add hooks that should only occur in the context of a GraphQL Request.
+	 *
+	 * @author WebDevStudios
+	 * @since 1.0
+	 */
+	function wds_graphql_request_init() {
+		add_filter( 'registration_errors', 'wds_filter_registration_errors' );
+	}
+	add_action( 'init_graphql_request', 'wds_graphql_request_init' );
 
 	/**
 	 * Add file upload field to GF FieldValuesInput.


### PR DESCRIPTION
References https://github.com/WebDevStudios/nextjs-wordpress-starter/pull/450

### Description

Adds WP GraphQL Upload plugin.
Updates WP GraphQL Gravity Forms `fieldValuesInput` to include `fileUploadValues` using new `Upload` scalar type.
Adds function to handle a custom file upload, saving uploaded file to custom directory (GF form upload dir).
Extends WP GraphQL GF form submission resolver to use custom file upload function and save file upload data to form.

**Note: once merged, WP GraphQL Upload plugin will need to be activated.**

### Screenshots

![Screen Shot 2021-05-20 at 10 57 28 AM](https://user-images.githubusercontent.com/36422618/119019210-2f7f5000-b95a-11eb-8a5f-18ae0248d066.png)

### Steps To Verify Feature

Follow instructions on https://github.com/WebDevStudios/nextjs-wordpress-starter/pull/450
