### PR TITLE
Feature/410 preformatted block

### DIFF
--- a/themes/wds_headless/js/blocks.js
+++ b/themes/wds_headless/js/blocks.js
@@ -79,6 +79,8 @@ function wdsAddColorPaletteHexValues(settings) {
 					// Retrieve color hex value.
 					props.attributes.backgroundColorHex =
 						backgroundColorObj?.[0]?.color || null;
+				} else {
+					delete props.attributes.backgroundColorHex;
 				}
 
 				// Check for presence of main color attr.
@@ -91,6 +93,8 @@ function wdsAddColorPaletteHexValues(settings) {
 					// Retrieve color hex value.
 					props.attributes.mainColorHex =
 						mainColorObj?.[0]?.color || null;
+				} else {
+					delete props.attributes.mainColorHex;
 				}
 
 				// Check for presence of text color attr.
@@ -103,6 +107,8 @@ function wdsAddColorPaletteHexValues(settings) {
 					// Retrieve color hex value.
 					props.attributes.textColorHex =
 						textColorObj?.[0]?.color || null;
+				} else {
+					delete props.attributes.textColorHex;
 				}
 			}, [backgroundColor, mainColor, textColor]);
 

--- a/themes/wds_headless/js/blocks.js
+++ b/themes/wds_headless/js/blocks.js
@@ -28,28 +28,11 @@ addFilter(
 /**
  * Filter block registration to add custom color attributes to specified blocks.
  *
- * TODO: Extend this to apply to other blocks that use the color palette.
- *
+ * @author WebDevStudios
  * @param {object} settings Block settings config.
- * @param {string} name     Block name.
  * @return {object}         Block settings config.
  */
-function wdsAddColorPaletteHexValues(settings, name) {
-	/**
-	 * Filter the array of blocks to receive hex color values.
-	 *
-	 * @author WebDevStudios
-	 * @param {array} allowedBlocks Array of blocks.
-	 */
-	const allowedBlocks = applyFilters(
-		"wds/colorPaletteHexValuesAllowedBlocks",
-		["core/button", "core/paragraph", "core/pullquote"]
-	);
-
-	if (!allowedBlocks.includes(name)) {
-		return settings;
-	}
-
+function wdsAddColorPaletteHexValues(settings) {
 	// Add background color hex attribute.
 	if (settings.attributes.hasOwnProperty("backgroundColor")) {
 		settings.attributes.backgroundColorHex = {


### PR DESCRIPTION
References https://github.com/WebDevStudios/nextjs-wordpress-starter/pull/505

### Description

Expands hex color filter:
- Removes check for blocks - will apply hex values to all blocks with color settings for simplicity
- Removes hex color prop if corresponding color prop is not set

### Screenshots

![Screen Shot 2021-06-07 at 3 46 28 PM](https://user-images.githubusercontent.com/36422618/121091630-8a60d600-c7a7-11eb-8820-1b58142a96c3.png)

### Steps To Verify Feature

https://nextjsdevstart.wpengine.com/wp-admin/post.php?post=450&action=edit
- view in code editor to see hex attrs
