### PR TITLE
Add background gradient support

### DIFF
--- a/themes/wds_headless/functions.php
+++ b/themes/wds_headless/functions.php
@@ -50,9 +50,6 @@ function wds_theme_setup() {
 		]
 	);
 
-	// Disable background color gradient presets.
-	add_theme_support( 'editor-gradient-presets', [] );
-
 	// Reset available font size presets to only "normal" (16px).
 	add_theme_support(
 		'editor-font-sizes',

--- a/themes/wds_headless/js/blocks.js
+++ b/themes/wds_headless/js/blocks.js
@@ -1,4 +1,4 @@
-const { validateThemeColors } = wp.blockEditor;
+const { validateThemeColors, validateThemeGradients } = wp.blockEditor;
 const { useEffect } = wp.element;
 const { addFilter, applyFilters } = wp.hooks;
 
@@ -41,6 +41,14 @@ function wdsAddColorPaletteHexValues(settings) {
 		};
 	}
 
+	// Add gradient background hex attribute.
+	if (settings.attributes.hasOwnProperty("gradient")) {
+		settings.attributes.gradientHex = {
+			type: "string",
+			default: "",
+		};
+	}
+
 	// Add main color hex attribute.
 	if (settings.attributes.hasOwnProperty("mainColor")) {
 		settings.attributes.mainColorHex = {
@@ -61,13 +69,15 @@ function wdsAddColorPaletteHexValues(settings) {
 		...settings,
 		edit(props) {
 			const {
-				attributes: { backgroundColor, mainColor, textColor },
+				attributes: { backgroundColor, gradient, mainColor, textColor },
 			} = props;
 
 			useEffect(() => {
 				// Note: This may not work as expected if a custom theme palette has been set.
 				// In that case, this filter may need to be customized.
 				const defaultColors = validateThemeColors();
+
+				const defaultGradients = validateThemeGradients();
 
 				// Check for presence of background color attr.
 				if (backgroundColor) {
@@ -81,6 +91,20 @@ function wdsAddColorPaletteHexValues(settings) {
 						backgroundColorObj?.[0]?.color || null;
 				} else {
 					delete props.attributes.backgroundColorHex;
+				}
+
+				// Check for presence of gradient color attr.
+				if (gradient) {
+					// Get color object by slug.
+					const gradientObj = defaultGradients.filter(
+						(color) => color.slug === gradient
+					);
+
+					// Retrieve color hex value.
+					props.attributes.gradientHex =
+						gradientObj?.[0]?.gradient || null;
+				} else {
+					delete props.attributes.gradientHex;
 				}
 
 				// Check for presence of main color attr.


### PR DESCRIPTION
References https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/410

### Link

https://nextjsdevstart.wpengine.com/wp-admin/post.php?post=454&action=edit

### Description

Adds handling to pass actual CSS for gradient background presets to the FE.

### Screenshots

![Screen Shot 2021-06-08 at 2 50 12 PM](https://user-images.githubusercontent.com/36422618/121255667-e7709080-c868-11eb-91f8-18515889b249.png)

### Steps To Verify Feature

1. Edit a post (e.g., https://nextjsdevstart.wpengine.com/wp-admin/post.php?post=454&action=edit)
2. Apply a preset gradient
3. Switch to code view to confirm `gradientHex` attr is added
