### PR TITLE
Add overlay color hex handling

### DIFF
--- a/themes/wds_headless/js/blocks.js
+++ b/themes/wds_headless/js/blocks.js
@@ -57,6 +57,14 @@ function wdsAddColorPaletteHexValues(settings) {
 		};
 	}
 
+	// Add overlay color hex attribute.
+	if (settings.attributes.hasOwnProperty("overlayColor")) {
+		settings.attributes.overlayColorHex = {
+			type: "string",
+			default: "",
+		};
+	}
+
 	// Add text color hex attribute.
 	if (settings.attributes.hasOwnProperty("textColor")) {
 		settings.attributes.textColorHex = {
@@ -69,7 +77,13 @@ function wdsAddColorPaletteHexValues(settings) {
 		...settings,
 		edit(props) {
 			const {
-				attributes: { backgroundColor, gradient, mainColor, textColor },
+				attributes: {
+					backgroundColor,
+					gradient,
+					mainColor,
+					overlayColor,
+					textColor,
+				},
 			} = props;
 
 			useEffect(() => {
@@ -119,6 +133,20 @@ function wdsAddColorPaletteHexValues(settings) {
 						mainColorObj?.[0]?.color || null;
 				} else {
 					delete props.attributes.mainColorHex;
+				}
+
+				// Check for presence of overlay color attr.
+				if (overlayColor) {
+					// Get color object by slug.
+					const overlayColorObj = defaultColors.filter(
+						(color) => color.slug === overlayColor
+					);
+
+					// Retrieve color hex value.
+					props.attributes.overlayColorHex =
+						overlayColorObj?.[0]?.color || null;
+				} else {
+					delete props.attributes.overlayColorHex;
 				}
 
 				// Check for presence of text color attr.


### PR DESCRIPTION
### Description

Adds overlay hex color handling to attributes.

### Screenshots

![Screen Shot 2021-06-10 at 3 30 42 PM](https://user-images.githubusercontent.com/36422618/121599846-e07c8600-ca00-11eb-98ef-592465d88ce3.png)

### Steps To Verify Feature

https://nextjsdevstart.wpengine.com/wp-admin/post.php?post=468&action=edit