### PR TITLE
Feature/#34 GitHub actions

### DIFF
--- a/.github/workflows/assertions.yml
+++ b/.github/workflows/assertions.yml
@@ -2,7 +2,7 @@ name: Assertions
 
 on:
   pull_request:
-    branches: main
+    branches: [main, develop]
 
   workflow_dispatch:
 

--- a/.github/workflows/assertions.yml
+++ b/.github/workflows/assertions.yml
@@ -33,6 +33,9 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.OS }}-composer-
 
+      - name: Authorize Composer with WDS packagist server
+        run: echo '${{ secrets.COMPOSER_AUTH }}' > $GITHUB_WORKSPACE/auth.json
+
       - name: Install dependencies
         run: composer install
 

--- a/.github/workflows/assertions.yml
+++ b/.github/workflows/assertions.yml
@@ -1,0 +1,40 @@
+name: Assertions
+
+on:
+  pull_request:
+    branches: main
+
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-versions: ["7.4"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          token: ${{ github.token }}
+
+      - name: Setup PHP ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: composer:v2, phpcs
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.OS }}-composer-
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Lint PHP
+        run: composer run lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Dev
 on:
   push:
     branches:
-      - main
+      - develop
 
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy to Dev
+
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-versions: ["7.4"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          token: ${{ github.token }}
+
+      - name: Setup PHP ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: composer:v2
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.OS }}-composer-
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Rsync to prod
+        uses: easingthemes/ssh-deploy@v2
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
+          ARGS: "-v -a -z --delete"
+          SOURCE: "./"
+          REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+          REMOTE_USER: ${{ secrets.REMOTE_USER }}
+          TARGET: ${{ secrets.REMOTE_PATH }}
+          EXCLUDE: ".git*,.env,composer.json,composer.lock,auth.json,package.json,package-lock.json,node_modules/,/uploads/,/upgrade/,/advanced-cache.php,/object-cache.php,/debug.log,/mysql.sql,/mu-plugins/mu-plugin.php,/mu-plugins/wpengine-common/,/mu-plugins/wpe-wp-sign-on-plugin.php,/mu-plugins/wpe-wp-sign-on-plugin/,/mu-plugins/slt-force-strong-passwords.php,/mu-plugins/force-strong-passwords/,/mu-plugins/wpengine-security-auditor.php"
+
+      - name: Notify Slack
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: vercel-firehose
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_ICON: https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_192.png
+          SLACK_USERNAME: Github
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: ""


### PR DESCRIPTION
Closes #34 

### Link

N/A

### Description

This PR will move this project off Buddy, and over to Github Actions. This will free up Buddy for client work.

Post merge chores:

- [ ] Remove this project from Buddy

### Screenshots

![screenshot](https://dl.dropbox.com/s/z0e4u6gfxyqil9t/Screen%20Shot%202021-06-11%20at%2010.09.06.png?dl=0)

### Verify

- View the [successful assertion job](https://github.com/WebDevStudios/wds-headless-wordpress/runs/2804180045?check_suite_focus=true)