### PR TITLE
Fix/536 fix preview links

### DIFF
--- a/themes/wds_headless/inc/wordpress.php
+++ b/themes/wds_headless/inc/wordpress.php
@@ -164,3 +164,4 @@ function wds_set_headless_rest_preview_link( WP_REST_Response $response, WP_Post
 	return $response;
 }
 add_filter( 'rest_prepare_page', 'wds_set_headless_rest_preview_link', 10, 2 );
+add_filter( 'rest_prepare_post', 'wds_set_headless_rest_preview_link', 10, 2 );

--- a/themes/wds_headless/inc/wordpress.php
+++ b/themes/wds_headless/inc/wordpress.php
@@ -71,7 +71,7 @@ function wds_set_headless_preview_link( string $link, WP_Post $post ) {
 			'name'      => $slug,
 			'id'        => $post->ID,
 			'post_type' => $post_type,
-			'token'     => defined( 'WORDPRESS_PREVIEW_SECRET' ) ? WORDPRESS_PREVIEW_SECRET : '',
+			'token'     => defined( 'PREVIEW_SECRET_TOKEN' ) ? PREVIEW_SECRET_TOKEN : '',
 		],
 		"{$base_url}api/preview"
 	);


### PR DESCRIPTION
Closes https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/536

### Link

https://nextjsdevstart.wpengine.com/wp-admin/post.php?post=483&action=edit

### Description

Updates the preview token const name for preview URLs.
Adds REST link filter for posts.

### Screenshots

![Screen Shot 2021-07-21 at 3 43 39 PM](https://user-images.githubusercontent.com/36422618/126564210-9db1429c-edcc-43c6-8b74-dc5072b9a27c.png)

### Steps To Verify Feature

https://nextjsdevstart.wpengine.com/wp-admin/post.php?post=483&action=edit
- click to preview draft post
