### PR TITLE
dependebot 2021-08-16

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -376,16 +376,16 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.207.0",
+            "version": "v0.208.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "bd88717a5526f0db721e8f4309ef06d142894844"
+                "reference": "77fdacfc99f582970dcb3c41233158b02cc4ba5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/bd88717a5526f0db721e8f4309ef06d142894844",
-                "reference": "bd88717a5526f0db721e8f4309ef06d142894844",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/77fdacfc99f582970dcb3c41233158b02cc4ba5e",
+                "reference": "77fdacfc99f582970dcb3c41233158b02cc4ba5e",
                 "shasum": ""
             },
             "require": {
@@ -414,9 +414,9 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.207.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.208.0"
             },
-            "time": "2021-08-08T11:20:24+00:00"
+            "time": "2021-08-15T11:18:25+00:00"
         },
         {
             "name": "google/auth",
@@ -1054,16 +1054,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.9",
+            "version": "3.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "a127a5133804ff2f47ae629dd529b129da616ad7"
+                "reference": "62fcc5a94ac83b1506f52d7558d828617fac9187"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/a127a5133804ff2f47ae629dd529b129da616ad7",
-                "reference": "a127a5133804ff2f47ae629dd529b129da616ad7",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/62fcc5a94ac83b1506f52d7558d828617fac9187",
+                "reference": "62fcc5a94ac83b1506f52d7558d828617fac9187",
                 "shasum": ""
             },
             "require": {
@@ -1145,7 +1145,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.9"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.10"
             },
             "funding": [
                 {
@@ -1161,7 +1161,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-14T06:54:45+00:00"
+            "time": "2021-08-16T04:24:45+00:00"
         },
         {
             "name": "pristas-peter/wp-graphql-gutenberg",
@@ -1702,10 +1702,10 @@
         },
         {
             "name": "webdevstudios/gravityforms",
-            "version": "2.5.8",
+            "version": "2.5.9",
             "dist": {
                 "type": "tar",
-                "url": "https://packages.wdslab.com/dist/webdevstudios/gravityforms/webdevstudios-gravityforms-2.5.8.tar"
+                "url": "https://packages.wdslab.com/dist/webdevstudios/gravityforms/webdevstudios-gravityforms-2.5.9.tar"
             },
             "require": {
                 "composer/installers": "^1.0"
@@ -2052,15 +2052,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-graphql",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-graphql/",
-                "reference": "tags/1.6.2"
+                "reference": "tags/1.6.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-graphql.1.6.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-graphql.1.6.3.zip"
             },
             "require": {
                 "composer/installers": "~1.0"


### PR DESCRIPTION
Related PR: https://github.com/WebDevStudios/nextjs-wordpress-starter/pull/596

### Link

https://nextjsdevstart.wpengine.com/wp-admin/index.php

https://nextjs-wordpress-starter-git-feature-depen-dce646-webdevstudios.vercel.app/

### Description

This PR updates the following Composer dependencies:

```bash
google/apiclient-services (v0.207.0 => v0.208.0)
phpseclib/phpseclib (3.0.9 => 3.0.10)
webdevstudios/gravityforms (2.5.8 => 2.5.9)
wpackagist-plugin/wp-graphql (1.6.2 => 1.6.3)
```

### Screenshots

WP Backend:
![screenshot](https://dl.dropbox.com/s/y3o8vc3rqy5i2iy/Screen%20Shot%202021-08-16%20at%207.50.55%20AM.png?dl=0)

Frontend:
![screenshot](https://dl.dropbox.com/s/0ubq17fhbq16lc0/Screen%20Shot%202021-08-16%20at%207.55.04%20AM.png?dl=0)

### Steps To Verify Feature

How will your Lead Engineer and/or stakeholder test this?

1. `gh pr checkout 52`
2. Start the front-end `npm run build && npm start`
3. Verify everything works
